### PR TITLE
쿠폰 엔티티를 정의

### DIFF
--- a/src/payment/entities/coupon.entity.ts
+++ b/src/payment/entities/coupon.entity.ts
@@ -1,0 +1,17 @@
+import { Column, Entity, OneToMany, Relation } from 'typeorm';
+import { BaseEntity } from '../../common/entity';
+import { IssuedCoupon } from './issued-coupon.entity';
+
+type CouponType = 'percent' | 'fixed';
+
+@Entity()
+export class Coupon extends BaseEntity {
+  @Column({ type: 'varchar', length: 50 })
+  type: CouponType;
+
+  @Column({ type: 'decimal', precision: 5, scale: 2 })
+  value: number; // 할인율 또는 정액 금액
+
+  @OneToMany(() => IssuedCoupon, (issuedCoupon) => issuedCoupon.coupon)
+  issuedCoupons: Relation<IssuedCoupon[]>;
+}


### PR DESCRIPTION
- coupon.entity.ts
1. 기본적인 쿠폰 엔티티 정의를 해서 2가지 유형의 쿠폰을 정의
2. 일대다 관계를 설정해서 여러개의 발행된 쿠폰을 사용할 수 있도록 정의
3. 이를 issued-coupon엔터티간의 관계를 설정

- issued-coupon.entity.ts
1. 주문과의 관계는 단일관계이며 nullable:true로 인해 관계가 선택적
2. user와의 관계는 일대다 관계 = 여러개의 쿠폰 사용등과같은 상황
