### PR TITLE
포인트 엔티티 정의

### DIFF
--- a/src/payment/entities/point-log.entity.ts
+++ b/src/payment/entities/point-log.entity.ts
@@ -1,0 +1,32 @@
+import { Column, Entity, ManyToOne, Relation } from 'typeorm';
+import { BaseEntity } from '../../common/entity';
+import { Point } from './point.entity';
+
+export type PointLogType = 'earn' | 'spend';
+
+@Entity()
+export class PointLog extends BaseEntity {
+  @ManyToOne(() => Point, (point) => point.logs)
+  point: Relation<Point>;
+
+  @Column({ type: 'int', default: 0 })
+  amount: number; // 개별 적립 또는 사용 금액
+
+  @Column({ type: 'text' })
+  reason: string; // 개별 적립 또는 사용 사유
+
+  @Column({ type: 'varchar', length: 50 })
+  type: PointLogType;
+
+  use(amount: number, reason: string): void {
+    this.amount = amount;
+    this.reason = reason;
+    this.type = 'spend';
+  }
+
+  add(amount: number, reason: string): void {
+    this.amount = amount;
+    this.reason = reason;
+    this.type = 'earn';
+  }
+}

--- a/src/payment/entities/point.entity.ts
+++ b/src/payment/entities/point.entity.ts
@@ -1,0 +1,28 @@
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    OneToMany,
+    OneToOne,
+    Relation,
+  } from 'typeorm';
+  import { BaseEntity } from '../../common/entity';
+  import { PointLog } from './point-log.entity';
+  import { User } from '../../auth/entity/user.entity';
+  
+  @Entity()
+  export class Point extends BaseEntity {
+    @OneToOne(() => User, (user) => user.point)
+    @JoinColumn()
+    user: Relation<User>;
+  
+    @Column({ type: 'int' })
+    availableAmount: number;
+  
+    @OneToMany(() => PointLog, (pointLog) => pointLog.amount)
+    logs: Relation<PointLog[]>;
+  
+    use(amountToUse: number) {
+      this.availableAmount -= amountToUse;
+    }
+  }


### PR DESCRIPTION
- point.entity.ts
1. user엔티티와의 일다일 관계를 설정, JoinColumn을 통해 user가 외래키임을 정의
2. availabeAmount는 사용자의 포인트 잔액을 보여주는 역할
3. 포인트 사용기록을 위해 log엔티티와의 일대다 관계 (포인트 사용기록이 여러개이므로)
4. use 메서드를 통해 포인트 사용시 지정된 포인트 값을 차감하도록 함

- point-log.entity.ts
1. 포인트의 적립 및 사용과 같은 내용들을 기록하기 위한 엔티티
2. point 필드를 통해 각 사용자가 소유한 포인트 양을 나타내고 point엔티티와 다대일 관계를 설정
3. amount는 포인트 적립 or 사용 금액을 나타냄
4. reason은 적립 혹은 사용 이유
5. 적립일 경우 add메서드를 통해, 사용일 경우 use메서드를 통하도록 함
