### PR TITLE
포인트 레포지토리 정의

### DIFF
--- a/src/payment/repositories/point-log.repository.ts
+++ b/src/payment/repositories/point-log.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager, Repository } from 'typeorm';
+import { Point, PointLog } from '../entities';
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class PointLogRepository extends Repository<PointLog> {
+  constructor(
+    @InjectRepository(PointLog)
+    private readonly repo: Repository<PointLog>,
+    @InjectEntityManager()
+    private readonly entityManager: EntityManager,
+  ) {
+    super(repo.target, repo.manager, repo.queryRunner);
+  }
+
+  use(point: Point, amountToUse: number, reason: string): Promise<PointLog> {
+    const pointLog = new PointLog();
+    pointLog.point = point;
+    pointLog.use(amountToUse, reason);
+    return this.save(pointLog);
+  }
+}

--- a/src/payment/repositories/point.repository.ts
+++ b/src/payment/repositories/point.repository.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager, Repository } from 'typeorm';
+import { Point } from '../entities';
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { PointLogRepository } from './point-log.repository';
+
+@Injectable()
+export class PointRepository extends Repository<Point> {
+  constructor(
+    @InjectRepository(Point)
+    private readonly repo: Repository<Point>,
+    @InjectEntityManager()
+    private readonly entityManager: EntityManager,
+    private readonly pointLogRepository: PointLogRepository,
+  ) {
+    super(repo.target, repo.manager, repo.queryRunner);
+  }
+
+  async use(userId, amountToUse: number, reason: string): Promise<Point> {
+    const point = await this.findOne({ where: { user: { id: userId } } });
+    point.use(amountToUse);
+    await this.pointLogRepository.use(point, amountToUse, reason);
+    return this.save(point);
+  }
+}


### PR DESCRIPTION
1. inject를 통해서 엔티티를 주입받고
2. 로그를 작성하기 위해 private readonly pointLogRepository: PointLogRepository, 를 추가
결과적으로 포인트를 사용할 때 이 레포지토리를 가져와서 서비스를 호출하고 포인트를 적립 혹은 사용에 대한 로그를 남기도록함